### PR TITLE
remove errant extra quote

### DIFF
--- a/doc_source/policy-conditions.md
+++ b/doc_source/policy-conditions.md
@@ -198,7 +198,7 @@ This policy allows the principal to use the CMK in a `GenerateDataKey` request o
   "Action": "kms:GenerateDataKey",
   "Resource": "*",
   "Condition": {
-    ""ForAnyValue:StringEquals": {
+    "ForAnyValue:StringEquals": {
       "kms:EncryptionContext:AppName": "ExampleApp"
     }
   }


### PR DESCRIPTION
*Description of changes:*

There was an extra quote in the condition policy example.

...I have no idea why the wrapping algorithm line is flagging as a diff...Atom wanted to auto-correct a bunch of lines and even Vim decided it had to make a non-change on that one extra line.. *shrugs*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
