### PR TITLE
Add missing kms service to arn examples

### DIFF
--- a/doc_source/kms-api-permissions-reference.md
+++ b/doc_source/kms-api-permissions-reference.md
@@ -8,12 +8,12 @@ The Actions and Resources Table is designed to help you define [access control](
   Each resource type is associated with an ARN that you use to represent the resource\.  
 CMK ARNs  
 When the resource is a CMK, you represent it by using a CMK ARN\.  
-`arn:AWS_partition_name:AWS_Region:AWS_account_ID:key/CMK_key_ID`  
+`arn:AWS_partition_name:kms:AWS_Region:AWS_account_ID:key/CMK_key_ID`  
 For example:  
 arn:aws:kms:us\-west\-2:111122223333:key/1234abcd\-12ab\-34cd\-56ef\-1234567890ab  
 Alias ARNs  
 When the resource is an alias, you represent it by using an alias ARN\.  
-`arn:AWS_partition_name:AWS_region:AWS_account_ID:alias/alias_name`  
+`arn:AWS_partition_name:kms:AWS_region:AWS_account_ID:alias/alias_name`  
 For example:  
 arn:aws:kms:us\-west\-2:111122223333:alias/ExampleAlias
 + **AWS KMS condition keys** lists the AWS KMS condition keys that you can use to control access to the operation\. You specify conditions in a policy's `Condition` element\. For more information, see [AWS KMS condition keys](policy-conditions.md#conditions-kms)\. This column also includes [AWS global condition keys](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_condition-keys.html) that are supported by AWS KMS, but not by all AWS services\.


### PR DESCRIPTION
https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html is missing the kms service in some of the arn examples.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
