### PR TITLE
add missing period and link to aws kms features page in AWS managed C…

### DIFF
--- a/doc_source/concepts.md
+++ b/doc_source/concepts.md
@@ -59,7 +59,7 @@ Customer managed CMKs incur a monthly fee and a fee for use in excess of the fre
 
 ### AWS managed CMKs<a name="aws-managed-cmk"></a>
 
-*AWS managed CMKs* are CMKs in your account that are created, managed, and used on your behalf by an AWS service that is integrated with AWS KMS\. Some AWS services support only an AWS managed CMK. For a list of AWS Services integrated with AWS KMS, see [AWS Key Management Service features](https://aws.amazon.com/kms/features/)\.   
+*AWS managed CMKs* are CMKs in your account that are created, managed, and used on your behalf by an AWS service that is integrated with AWS KMS\. Some AWS services support only an AWS managed CMK. For a list of AWS Services integrated with AWS KMS, see [AWS Services Integrated with AWS KMS](https://aws.amazon.com/kms/features/#AWS_Service_Integration)\.   
 
 You can [view the AWS managed CMKs](viewing-keys.md) in your account, [view their key policies](key-policy-viewing.md), and [audit their use](logging-using-cloudtrail.md) in AWS CloudTrail logs\. However, you cannot manage these CMKs, rotate them, or change their key policies\. And, you cannot use AWS managed CMKs in cryptographic operations directly; the service that creates them uses them on your behalf\. 
 

--- a/doc_source/concepts.md
+++ b/doc_source/concepts.md
@@ -59,7 +59,7 @@ Customer managed CMKs incur a monthly fee and a fee for use in excess of the fre
 
 ### AWS managed CMKs<a name="aws-managed-cmk"></a>
 
-*AWS managed CMKs* are CMKs in your account that are created, managed, and used on your behalf by an AWS service that is integrated with AWS KMS\. Some AWS services support only an AWS managed CMK
+*AWS managed CMKs* are CMKs in your account that are created, managed, and used on your behalf by an AWS service that is integrated with AWS KMS\. Some AWS services support only an AWS managed CMK. For a list of AWS Services integrated with AWS KMS, see [AWS Key Management Service features](https://aws.amazon.com/kms/features/)\.   
 
 You can [view the AWS managed CMKs](viewing-keys.md) in your account, [view their key policies](key-policy-viewing.md), and [audit their use](logging-using-cloudtrail.md) in AWS CloudTrail logs\. However, you cannot manage these CMKs, rotate them, or change their key policies\. And, you cannot use AWS managed CMKs in cryptographic operations directly; the service that creates them uses them on your behalf\. 
 


### PR DESCRIPTION
Fixed a minor grammatical issue. The AWS managed CMKs section was missing a period after "Some AWS Services support only an AWS managed CMK" https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html

I added a period and also added a link to the kms features page where users can see a list of AWS Services integrated with AWS KMS.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
