### PR TITLE
Update key-policies.md

### DIFF
--- a/doc_source/key-policies.md
+++ b/doc_source/key-policies.md
@@ -71,7 +71,7 @@ You cannot delete your AWS account's root user, so allowing access to this user 
 In this scenario, the CMK is now unmanageable, and you must [contact AWS Support](https://console.aws.amazon.com/support/home#/case/create) to regain access to the CMK\. The root user does not have access to the CMK, because the root user can access a CMK only when the key policy explicitly allows it\. This is different from most other resources in AWS, which implicitly allow access to the root user\.
 
 **2\. Enables IAM policies to allow access to the CMK\.**  
-IAM policies by themselves are not sufficient to allow access to a CMK\. However, you can use them in combination with a CMK's key policy if the key policy enables it\. Giving the AWS account full access to the CMK does this; it enables you to use IAM policies to give IAM users and roles in the account access to the CMK\. It does not by itself give any IAM users or roles access to the CMK, but it enables you to use IAM policies to do so\. For more information, see [Managing access to AWS KMS CMKs](control-access-overview.md#managing-access)\.
+IAM policies by themselves are sufficient to allow access to a CMK\. However, you can use them in combination with a CMK's key policy if the key policy enables it\. Giving the AWS account full access to the CMK does this; it enables you to use IAM policies to give IAM users and roles in the account access to the CMK\. It does not by itself give any IAM users or roles access to the CMK, but it enables you to use IAM policies to do so\. For more information, see [Managing access to AWS KMS CMKs](control-access-overview.md#managing-access)\.
 
 The following example shows the policy statement that allows access to the AWS account and thereby enables IAM policies\.
 


### PR DESCRIPTION
Line 74 is wrong. If I create a user which has the following policy: 
    "kms:Decrypt",
    "kms:DescribeKey",
    "kms:Encrypt",
    "kms:GenerateDataKey*",
    "kms:ReEncrypt*"

They WILL be able to encrypt using the following command: aws kms encrypt --key-id <insert_key_ID> --plaintext "ABC"

even though they are NOT added in the Key Users section of the CMK in question. This was tested. 
Additionally, if the user has NO IAM policy attached, and they are added only under the Key Policy (or as a User of the CMK), they will be able to encrypt data. So it seems that the access is given if either/or the IAM policy or the Key user are added.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
