### PR TITLE
Update control-access-overview.md

### DIFF
--- a/doc_source/control-access-overview.md
+++ b/doc_source/control-access-overview.md
@@ -44,11 +44,11 @@ AWS KMS provides a set of API operations to work with your AWS KMS resources\. F
 The primary way to manage access to your AWS KMS CMKs is with *policies*\. Policies are documents that describe who has access to what\. Policies attached to an IAM identity are called *identity\-based policies* \(or *IAM policies*\), and policies attached to other kinds of resources are called *resource\-based policies*\. In AWS KMS, you must attach resource\-based policies to your customer master keys \(CMKs\)\. These are called *key policies*\. All KMS CMKs have a key policy\.
 
 You can control access to your KMS CMKs in these ways:
-+ **Use the key policy** – You must use the key policy to control access to a CMK\. You can use the key policy alone to control access, which means the full scope of access to the CMK is defined in a single document \(the key policy\)\.
++ **Use the key policy** – You can use the key policy alone to control access, which means the full scope of access to the CMK is defined in a single document \(the key policy\)\.
 + **Use IAM policies in combination with the key policy** – You can use IAM policies in combination with the key policy to control access to a CMK\. Controlling access this way enables you to manage all of the permissions for your IAM identities in IAM\.
 + **Use grants in combination with the key policy** – You can use grants in combination with the key policy to allow access to a CMK\. Controlling access this way enables you to allow access to the CMK in the key policy, and to allow users to delegate their access to others\.
 
-For most AWS services, IAM policies are the only way to control access to the service's resources\. Some services offer resource\-based policies or other access control mechanisms to complement IAM policies, but these are generally optional and you can control access to the resources in these services with only IAM policies\. This is not the case for AWS KMS, however\. To allow access to a KMS CMK, you must use the key policy, either alone or in combination with IAM policies or grants\. IAM policies by themselves are not sufficient to allow access to a CMK, though you can use them in combination with a CMK's key policy\.
+For most AWS services, IAM policies are the only way to control access to the service's resources\. Some services offer resource\-based policies or other access control mechanisms to complement IAM policies, but these are generally optional and you can control access to the resources in these services with only IAM policies\. To allow access to a KMS CMK, you must use the key policy, either alone or in combination with IAM policies or grants\. 
 
 For more information about using key policies, see [Using key policies](key-policies.md)\.
 


### PR DESCRIPTION
You can control the crypto-usage (ex. Encrypt, Decrypt) of a KMS key through an IAM policy attached to a user, even without explicitly adding them as a KMS CMK Key-User, and doing so with the default (non-modified) Key-Policy that is in place. In other words, once the KMS CMK key is created through the GUI console (as well as its default Key-Policy), it is possible to assign a user or a role the IAM permissions to encrypt/decrypt data. The documentation seems to say imply that Key-Policy should allow that access, regardless of any IAM policies. 

To test: create a CMK with all the defaults, and without adding any Admin or any Key-Users. Create a new IAM user, and assign them the following: 
    "kms:Decrypt",
    "kms:DescribeKey",
    "kms:Encrypt",
    "kms:GenerateDataKey*",
    "kms:ReEncrypt*"

That IAM user would be able to encrypt data, through the CLI, even though the default Key-Policy was not modified, and even though they were never added under the Key Users section of the CMK. If this behavior is normal, I believe the documentation should be changed to reflect all of this.

