### PR TITLE
fix permission

### DIFF
--- a/doc_source/services-secrets-manager.md
+++ b/doc_source/services-secrets-manager.md
@@ -102,7 +102,7 @@ In the past, Secrets Manager validation calls did not include an encryption cont
 When Secrets Manager uses a [customer master key](concepts.md#master_keys) \(CMK\) in cryptographic operations, it acts on behalf of the user who is creating or changing the secret value in the secret\.
 
 To use the AWS KMS customer master key \(CMK\) for a secret on your behalf, the user must have the following permissions\. You can specify these required permissions in an IAM policy or key policy\.
-+ kms:GenerateDataKey
++ kms:GenerateDataKey*
 + kms:Decrypt
 
 To allow the CMK to be used only for requests that originate in Secrets Manager, you can use the [kms:ViaService condition key](policy-conditions.md#conditions-kms-via-service) with the `secretsmanager.<region>.amazonaws.com` value\.


### PR DESCRIPTION
Dear AWS Team, I found a small bug when trying to get a secret value from Secrets Manager which is protected by a KMS CMK.

When running, e.g. an EC2 instance with the following permissions 
```
- secretsmanager:*
- kms:GenerateDataKey
- kms:Decrypt
```
and trying to get a secret value with 

`aws secretsmanager get-secret-value --secret-id <> --query SecretString`

will result in 

`An Error occured (AccessDeniedException) when calling the GetSecretValue operation: Access to KMS is not allowed`.


